### PR TITLE
Don't use empty string for args to -i, causes errors

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -71,7 +71,7 @@ echo "exiting..."
 #if [ "${found}" ] ; then
  
 echo " (i) Replacing..."
-sed -i '' -e 's%'"$old_value"'%'"$new_value"'%g' ${file}
+sed -i -e 's%'"$old_value"'%'"$new_value"'%g' ${file}
 echo " (i) Done"
 
 


### PR DESCRIPTION
I was running this in bitrise, it's a great step, but kept complaining about file not found. After some trial and error, it looks like the -i '' is the culprit. Changing it to -i without the '' seemed to make it happier. 
